### PR TITLE
Adds tagging to the recipe app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'activerecord', '~>4.1'
 gem 'rake'
 
 gem 'shotgun'
+gem 'pry'
 
 group :test do
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,38 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.1.1)
-      activesupport (= 4.1.1)
+    activemodel (4.2.3)
+      activesupport (= 4.2.3)
       builder (~> 3.1)
-    activerecord (4.1.1)
-      activemodel (= 4.1.1)
-      activesupport (= 4.1.1)
-      arel (~> 5.0.0)
-    activesupport (4.1.1)
-      i18n (~> 0.6, >= 0.6.9)
+    activerecord (4.2.3)
+      activemodel (= 4.2.3)
+      activesupport (= 4.2.3)
+      arel (~> 6.0)
+    activesupport (4.2.3)
+      i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (5.0.1.20140414130214)
+    arel (6.0.3)
     backports (3.6.0)
     builder (3.2.2)
+    coderay (1.1.0)
     daemons (1.1.9)
     diff-lcs (1.2.5)
     eventmachine (1.0.8)
     faker (1.3.0)
       i18n (~> 0.5)
-    i18n (0.6.9)
-    json (1.8.1)
-    minitest (5.3.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    method_source (0.8.2)
+    minitest (5.8.0)
     multi_json (1.10.1)
     pg (0.17.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -54,13 +60,14 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (~> 1.3)
+    slop (3.6.0)
     thin (1.6.2)
       daemons (>= 1.0.9)
       eventmachine (>= 1.0.0)
       rack (>= 1.0.0)
-    thread_safe (0.3.3)
+    thread_safe (0.3.5)
     tilt (1.4.1)
-    tzinfo (1.1.0)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -71,6 +78,7 @@ DEPENDENCIES
   activesupport (~> 4.1)
   faker
   pg
+  pry
   rake
   rspec
   shotgun

--- a/app/controllers/tags.rb
+++ b/app/controllers/tags.rb
@@ -1,4 +1,8 @@
-get "/tags/:id" do
-  @tag = Tag.find(params[:id])
-  erb :"tags/show"
+get "/tags/:name" do
+  @tag = Tag.find_by(name: params[:name])
+  if @tag
+    erb :"tags/show"
+  else
+    404
+  end
 end

--- a/app/controllers/tags.rb
+++ b/app/controllers/tags.rb
@@ -1,0 +1,4 @@
+get "/tags/:id" do
+  @tag = Tag.find(params[:id])
+  erb :"tags/show"
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,3 +1,5 @@
 class Recipe < ActiveRecord::Base
   validates :title, presence: true
+  has_many :taggings
+  has_many :tags, through: :taggings
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -2,4 +2,22 @@ class Recipe < ActiveRecord::Base
   validates :title, presence: true
   has_many :taggings
   has_many :tags, through: :taggings
+
+  def tag_names=(tag_string)
+    tag_names = tag_string.split(",")
+    tags = tag_names.map do |name|
+      # normalize the name (strip all the leading and trailing whitespace)
+      name = name.strip.downcase
+      # if a tag with this name exists, use that
+      # otherwise, build a new tag
+      tag = Tag.find_by(name: name) || Tag.new(name: name)
+    end
+    self.tags = tags
+  end
+
+  def tag_names
+    # pluck the names from the tags association
+    # join them with commas
+    self.tags.pluck(:name).join(", ")
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,5 @@
+class Tag < ActiveRecord::Base
+  validates :name, uniqueness: true
+  has_many :taggings
+  has_many :recipes, through: :taggings
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,4 +2,8 @@ class Tag < ActiveRecord::Base
   validates :name, uniqueness: true
   has_many :taggings
   has_many :recipes, through: :taggings
+
+  def to_param
+    self.name
+  end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,4 @@
+class Tagging < ActiveRecord::Base
+  belongs_to :recipe
+  belongs_to :tag
+end

--- a/app/views/recipes/_form_fields.erb
+++ b/app/views/recipes/_form_fields.erb
@@ -10,3 +10,8 @@
   <label for="recipe[ingredients]">Ingredients:</label>
   <textarea name="recipe[ingredients]"><%= @recipe.ingredients %></textarea>
 </div>
+
+<div class="form-field">
+  <label for="recipe[tag_names]">Tags:</label>
+  <input type="text" name="recipe[tag_names]" value="<%= @recipe.tag_names %>" />
+</div>

--- a/app/views/recipes/show.erb
+++ b/app/views/recipes/show.erb
@@ -6,6 +6,12 @@
   <% end %>
 </ul>
 
+<p>
+  <% @recipe.tags.each do |tag| %>
+    <a href="/tags/<%= tag.id %>"><%= tag.name %></a>
+  <% end %>
+</p>
+
 <a href="<%= edit_recipe_path(@recipe) %>">Edit</a> | 
 
 <form action="<%= recipe_path(@recipe) %>" method="post">

--- a/app/views/recipes/show.erb
+++ b/app/views/recipes/show.erb
@@ -8,7 +8,7 @@
 
 <p>
   <% @recipe.tags.each do |tag| %>
-    <a href="/tags/<%= tag.id %>"><%= tag.name %></a>
+    <a href="/tags/<%= tag.to_param %>"><%= tag.name %></a>
   <% end %>
 </p>
 

--- a/app/views/tags/show.erb
+++ b/app/views/tags/show.erb
@@ -1,0 +1,7 @@
+<h1><%= @tag.name %></h1>
+
+<ul>
+  <% @tag.recipes.each do |recipe| %>
+  <li><a href="/recipes/<%= recipe.id %>"><%= recipe.title %></a></li>
+  <% end %>
+</ul>

--- a/db/migrate/20150820081224_create_tags_and_taggings.rb
+++ b/db/migrate/20150820081224_create_tags_and_taggings.rb
@@ -1,0 +1,23 @@
+class CreateTagsAndTaggings < ActiveRecord::Migration
+  def change
+    ##### TAGS ######
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    # name is used as a lookup field, so it should be indexed
+    add_index :tags, :name, unique: true
+
+    ##### TAGGINGS ######
+    create_table :taggings do |t|
+      t.references :tag
+      t.references :recipe
+    end
+
+    # on join tables it's necessary to create a composite index
+    # with both foreign_keys, as well as an index for just the
+    # second foreign_key in the composite key
+    add_index :taggings, [:tag_id, :recipe_id]
+    add_index :taggings, :recipe_id
+  end
+end


### PR DESCRIPTION
We covered:

Goals:

1. create tags and taggings using a field on the new recipe form
2. demonstrate how to use a virtual attribute to refactor the controller code
3. use a nested route to see recipes for a given tag
4. use tag names in the routes rather than ids

### Virtual Attribute
In ActiveRecord we have the concept of attributes, which are fields that are backed by a field in the database. But there are times when we want to interact with an attribute that isn't in the database. This is where virtual attributes come in. In this case, we used a virtual attribute to allow us to interact with the `tags` association as a comma separated string, instead of `Tag` objects.

### Nested Routes (where to display a list of Recipes for a given tag)

Option 1: 
create show page for a single tag and include a list of recipes there. Route: `/tags/:id`

Option 2:
create an index for recipes for a single tag. Route: `/tags/:id/recipes`

Which option you choose is entirely your up to you and how you want to design your system. Option 2 is the most semantic (it'd be the route you'd create if you were building an JSON API for this data). Option 1 is simpler in terms of CRUD concepts. There's also not much to display on the Tag show page, if we don't put a list of recipes there.

In our case we chase Option 1, mostly for simplicity in our routes.

### ActiveRecord#to_param

`ActiveRecord#to_param` is intended to be used to specify which field to use when building paths for representing your models. So, it's the perfect candidate to use when we're trying to build out tag routes to use the tag name rather than the id. It also represents good OO. The views (already) know too much about the model, if they are deciding which field represents the model in a path.
